### PR TITLE
Question 153

### DIFF
--- a/questions/153/explanation.md
+++ b/questions/153/explanation.md
@@ -1,7 +1,7 @@
-According to [lex.string]§2.14.5¶8 in the standard: "A narrow string literal has type “array of n const char”"
+According to [lex.string]§5.13.5¶8 in the standard: "A narrow string literal has type “array of n const char”"
 
-An array of n const char converts to a pointer to const char. According to  [conv.qual]§4.4¶1: "A prvalue of type “pointer to `cv1 T`” can be converted to a prvalue of type “pointer to `cv2 T`” if “`cv2 T`” is more cv-qualified than “`cv1 T`”." In this case however, `char*` is less cv-qualified than `const char *`, and the conversion is not allowed.
+An array of n const char converts to a pointer to const char. A note in [conv.qual]§7.5¶4 extrapolates from the preceeding normative passages that "a prvalue of type “pointer to `cv1 T`” can be converted to a prvalue of type “pointer to `cv2 T`” if “`cv2 T`” is more cv-qualified than “`cv1 T`”." In this case however, `char*` is less cv-qualified than `const char *`, and the conversion is not allowed.
 
-Note: While most compilers still allow `char const[]` to `char*` conversion with just a warning, this is not a legal conversion in C++11.
+Note: While most compilers still allow `char const[]` to `char*` conversion with just a warning, this is not a legal conversion since C++11.
 
 See also <http://dev.krzaq.cc/stop-assigning-string-literals-to-char-star-already/>


### PR DESCRIPTION
 Fixes #1 
The passage in conv.qual had been changed to a non-normative note, but the normative wording is quite complex, so I left the note in.
