### PR TITLE
Question 131

### DIFF
--- a/questions/131/explanation.md
+++ b/questions/131/explanation.md
@@ -1,10 +1,14 @@
 These are two examples of initialization. The first form, `C c1(7)`, is called direct-initialization, the second, `C c2 = 7`, is called copy-initialization. In most cases they are equivalent, but in this example they are not, since the `int` constructor is `explicit`.
 
-They key is in [class.conv.ctor]§12.3.1¶2 : "An explicit constructor constructs objects just like non-explicit constructors, but does so only where the direct-initialization syntax (8.5) or where casts (5.2.9, 5.4) are explicitly used."
+The key is in [over.match.copy]§16.3.1.4¶1 :
+"[...] as part of a copy-initialization of an object of class type, a user-defined conversion can be invoked to convert an initializer expression to the type of the object being initialized. [...] the candidate functions are selected as follows:
+- [...]
+- When the type of the initializer expression is a class type "cv `S`", the *non-explicit* conversion functions of `S` and its base classes are considered. [...]
+(emphasis added)
 
 And how is direct-initialization defined?
 
-[dcl.init]§8.5¶15: "The initialization that occurs in the forms
+[dcl.init]§11.6¶16: "The initialization that occurs in the forms
 `T x(a);`
 `T x{a};`
 (...) is called direct-initialization."


### PR DESCRIPTION
 Fixes #97 

The old standards quote about explicitness was a non-normative note. The normative text is clear enough, so I replaced it.